### PR TITLE
Feature to skip rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 python script to transfer csv data to a certain website
 
 ```
-usage: main.py [-h] --csv_path CSV_PATH [--dry_run]
-               [--fail_csv_path FAIL_CSV_PATH] [--server SERVER_ADDRESS]
+usage: main.py [-h] --csv_path CSV_PATH [--entrymap_path ENTRYMAP_PATH]
+               [--dry_run] [--fail_csv_path FAIL_CSV_PATH]
+               [--duplicate_column_name DUPLICATE_COLUMN_NAME]
+               [--server SERVER_ADDRESS] --user AUTH_USERNAME --pass
+               AUTH_PASSWORD --auth AUTH_API
 
 Parse a specifically formatted CSV
 
@@ -11,10 +14,56 @@ optional arguments:
   -h, --help            show this help message and exit
   --csv_path CSV_PATH, -c CSV_PATH
                         the path to the csv file
+  --entrymap_path ENTRYMAP_PATH, -e ENTRYMAP_PATH
+                        the path to the JSON mapping file for db column names
+                        to csv column names
   --dry_run, -d         performs a dry run locally when provided with a
                         server_address
   --fail_csv_path FAIL_CSV_PATH, -f FAIL_CSV_PATH
                         the path to drop a csv with failed entries
+  --duplicate_column_name DUPLICATE_COLUMN_NAME, -dc DUPLICATE_COLUMN_NAME
+                        The column name where duplicate is marked and skipped.
+                        If there are any values within that column, it will
+                        count as a hit.
   --server SERVER_ADDRESS, -s SERVER_ADDRESS
                         the server address for the results to be uploaded
+  --user AUTH_USERNAME, -u AUTH_USERNAME
+                        the username to log in to the api with
+  --pass AUTH_PASSWORD, -p AUTH_PASSWORD
+                        the password to log in to the api with
+  --auth AUTH_API, -a AUTH_API
+                        the auth api
+
 ```
+
+## Entry Map JSON File
+
+An entry map should be a json file with the `csv column name` as the key and the `db column name` as the value.
+
+For example:
+
+If you want to insert the below CSV file:
+
+|time|csv_col_a|csv_col_b|
+|--|--|--|
+|115901|aaaaaa|bbbbbb|
+
+Into the DB table below:
+
+|db_col_1|db_col_2|
+|--|--|
+|bbbbbb|aaaaaa|
+
+I would need to create a the below JSON mapping file:
+```
+{
+  'csv_col_a': 'db_col_2',
+  'csv_col_b': 'db_col_1',
+}
+```
+
+The time column in the csv will be ignored.
+
+## Duplicate Entries to Ignore
+
+Use the `--duplicate_column_name` argument to add in the name of the CSV column that you want to use to ignore a row completely. Any values within that cell will automatically skip the entire row.

--- a/main.py
+++ b/main.py
@@ -89,6 +89,11 @@ def build_entrymap(csv_column_names, column_map) -> Dict:
 def send_entry(server, entry, entrymap, dry_run, authkey):
     postdata = {}
     for column_name, csv_index in entrymap.items():
+        # Skip the entry if a column identifying duplicates exists
+        if column_name == DUPLICATE_ARG_NAME:
+            if entry[csv_index]:
+                return 200, None, None
+            continue
         postdata[column_name] = entry[csv_index]
 
     print(postdata)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import argparse
 import csv
 import json
-from typing import Dict
+from typing import Dict, List, Tuple
 
 import requests
 
@@ -9,7 +9,7 @@ import requests
 DUPLICATE_ARG_NAME = "duplicate"
 
 
-def auth(username, password, server):
+def auth(username: str, password: str, server: str) -> Dict:
     print(username)
     postdata = {'username': username, 'password': password}
     res = requests.post(server, json=postdata)
@@ -17,13 +17,13 @@ def auth(username, password, server):
     return res.json()
 
 
-def write_fail_csv(entries, path):
+def write_fail_csv(entries: List, path: str):
     with open(path, 'w') as csv_f:
         csv_w = csv.writer(csv_f, delimiter=',')
         csv_w.writerows(entries)
 
 
-def parse_csv_to_memory(csv_path):
+def parse_csv_to_memory(csv_path: str) -> List[List]:
     """This probably doesn't need to be a function but it's separated for
     testability and to do additional functionality when parsing CSVs.
     """
@@ -33,7 +33,10 @@ def parse_csv_to_memory(csv_path):
     return csv_data
 
 
-def load_csv_to_db(csv_data, entrymap, server, authkey, dry_run=False):
+def load_csv_to_db(
+    csv_data: List[List], entrymap: Dict, server: str, authkey: Dict,
+    dry_run: bool = False
+) -> List[List]:
     failed_entries = []
     for entry in csv_data[1:]:
         # Do a dry run if no server address
@@ -48,7 +51,7 @@ def load_csv_to_db(csv_data, entrymap, server, authkey, dry_run=False):
     return failed_entries
 
 
-def build_entrymap(csv_column_names, column_map) -> Dict:
+def build_entrymap(csv_column_names: List, column_map: Dict) -> Dict:
     """Builds a db column name to csv column index mapping. If no mapping file
     is given, we naively create the mapping using the order of the rows.
 
@@ -86,7 +89,9 @@ def build_entrymap(csv_column_names, column_map) -> Dict:
     return db_column_to_index_map
 
 
-def send_entry(server, entry, entrymap, dry_run, authkey):
+def send_entry(
+    server: str, entry: List, entrymap: Dict, dry_run: bool, authkey: Dict
+) -> Tuple[int, str, Dict]:
     postdata = {}
     for column_name, csv_index in entrymap.items():
         # Skip the entry if a column identifying duplicates exists

--- a/main.py
+++ b/main.py
@@ -1,8 +1,12 @@
 import argparse
 import csv
 import json
+from typing import Dict
 
 import requests
+
+
+DUPLICATE_ARG_NAME = "duplicate"
 
 
 def auth(username, password, server):
@@ -44,12 +48,14 @@ def load_csv_to_db(csv_data, entrymap, server, authkey, dry_run=False):
     return failed_entries
 
 
-def build_entrymap(csv_column_names, column_map):
+def build_entrymap(csv_column_names, column_map) -> Dict:
     """Builds a db column name to csv column index mapping. If no mapping file
     is given, we naively create the mapping using the order of the rows.
 
     column_map provided should be {csv column name: db column name},
     not including the primary ID.
+
+    The function returns {db column name: csv column index}
     """
     # Naive approach, assumes the csv column names matches the db column names
     db_content_names = csv_column_names[1:]
@@ -111,6 +117,8 @@ def main(argv):
     if argv.entrymap_path is not None:
         with open(argv.entrymap_path, "r") as fp:
             column_map = json.load(fp)
+        if argv.duplicate_column_name is not None:
+            column_map[argv.duplicate_column_name] = DUPLICATE_ARG_NAME
     else:
         column_map = None
 
@@ -155,8 +163,8 @@ if __name__ == "__main__":
         default='./failed_entires.csv',
         help='the path to drop a csv with failed entries')
     parser.add_argument(
-        '--duplicate_column', '-dc', dest='duplicate_column', required=False,
-        default=None,
+        '--duplicate_column_name', '-dc', dest='duplicate_column_name',
+        required=False, default=None,
         help='The column name where duplicate is marked and skipped. If there '
         'are any values within that column, it will count as a hit.')
     parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ import requests
 DUPLICATE_ARG_NAME = "duplicate"
 
 
-def auth(username: str, password: str, server: str) -> Dict:
+def generate_authkey(username: str, password: str, server: str) -> Dict:
     print(username)
     postdata = {'username': username, 'password': password}
     res = requests.post(server, json=postdata)
@@ -106,21 +106,27 @@ def send_entry(
         auth_headers = {'Authorization': 'JWT ' + authkey['access_token']}
         res = requests.post(server, json=postdata, headers=auth_headers)
         res_code = res.status_code
-        print(res_code, res.text)
+        res_text = res.text
+        print(res_code, res_text)
     else:
         res_code = 200  # STATUS CODE OK
-    return res_code, res.text, postdata
+        res_text = "Dry run, no response text"
+    return res_code, res_text, postdata
 
 
 def main(argv):
-    if argv.dry_run:
-        print("\nThis is a dry run. No data will be loaded to server whether "
-              "a server_address has been provided or not.\n")
+    if not argv.dry_run:
+        authkey = generate_authkey(
+            argv.auth_username, argv.auth_password, argv.auth_api)
     elif not argv.server_address:
+        authkey = None
         print("\nWARNING: A server address was not provided in args. "
               "Only printing results locally. Use the -h arg if you don't "
               "know what this means.\n")
-    authkey = auth(argv.auth_username, argv.auth_password, argv.auth_api)
+    else:
+        authkey = None
+        print("\nThis is a dry run. No data will be loaded to server whether "
+              "a server_address has been provided or not.\n")
 
     csv_data = parse_csv_to_memory(argv.csv_path)
 

--- a/main.py
+++ b/main.py
@@ -36,10 +36,10 @@ def load_csv_to_db(csv_data, entrymap, server, authkey, dry_run=False):
         if not server:
             dry_run = True
             server = '0.0.0.0'
-        res_code, postdata = send_entry(
+        res_code, res_text, postdata = send_entry(
             server, entry, entrymap, dry_run, authkey)
-        if res_code != 200 and res_code != 201:  # STATUS CODE not OK
-            entry.extend([postdata, res_code])
+        if res_code not in {200, 201}:  # STATUS CODE not OK
+            entry.extend([postdata, res_text, res_code])
             failed_entries.append(entry)
     return failed_entries
 
@@ -90,10 +90,10 @@ def send_entry(server, entry, entrymap, dry_run, authkey):
         auth_headers = {'Authorization': 'JWT ' + authkey['access_token']}
         res = requests.post(server, json=postdata, headers=auth_headers)
         res_code = res.status_code
-        print(res_code, res)
+        print(res_code, res.text)
     else:
         res_code = 200  # STATUS CODE OK
-    return res_code, postdata
+    return res_code, res.text, postdata
 
 
 def main(argv):

--- a/main.py
+++ b/main.py
@@ -111,6 +111,9 @@ def main(argv):
     if argv.entrymap_path is not None:
         with open(argv.entrymap_path, "r") as fp:
             column_map = json.load(fp)
+    else:
+        column_map = None
+
     entrymap = build_entrymap(
         csv_column_names=csv_data[0],
         column_map=column_map)
@@ -151,6 +154,11 @@ if __name__ == "__main__":
         '--fail_csv_path', '-f', dest='fail_csv_path',
         default='./failed_entires.csv',
         help='the path to drop a csv with failed entries')
+    parser.add_argument(
+        '--duplicate_column', '-dc', dest='duplicate_column', required=False,
+        default=None,
+        help='The column name where duplicate is marked and skipped. If there '
+        'are any values within that column, it will count as a hit.')
     parser.add_argument(
         '--server', '-s', dest='server_address', required=False,
         help='the server address for the results to be uploaded')

--- a/main.py
+++ b/main.py
@@ -115,16 +115,15 @@ def send_entry(
 
 
 def main(argv):
+    authkey = None
     if not argv.dry_run:
         authkey = generate_authkey(
             argv.auth_username, argv.auth_password, argv.auth_api)
     elif not argv.server_address:
-        authkey = None
         print("\nWARNING: A server address was not provided in args. "
               "Only printing results locally. Use the -h arg if you don't "
               "know what this means.\n")
     else:
-        authkey = None
         print("\nThis is a dry run. No data will be loaded to server whether "
               "a server_address has been provided or not.\n")
 


### PR DESCRIPTION
Add a feature to add a column to skip rows.

If you use the `--duplicate_column_name` or `-dc` argument, and provide a column name, any rows where there's a value in the column (doesn't matter what type of value) will be skipped and a return code of 200 is sent back for the POST operation.

A few more things this PR does:
 - Removes the need for dry runs to use auth. However, a username, pass, and auth still needs to be passed to run the script.
 - Type hints for readability
 - Fix a bug with the script without using column mapping
 - Add more context for POST failures by adding the response.text into the failure CSV